### PR TITLE
Modify kindtest to fail when other runners exist

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -41,9 +41,12 @@ jobs:
           make start-kind
           make load
       - run: |
-          stern . > kind.log &
+          ./bin/stern . --all-namespaces > kind.log &
       - run: |
           make prepare
           make kindtest
       - if: ${{ always() }}
-        run: cat kind.log
+        run: |
+          if [[ -f kind.log ]]; then
+            cat kind.log
+          fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,5 +40,10 @@ jobs:
           make images
           make start-kind
           make load
+      - run: |
+          stern . > kind.log &
+      - run: |
           make prepare
           make kindtest
+      - if: ${{ always() }}
+        run: cat kind.log

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CURL := curl -sSLf
 CONTROLLER_RUNTIME_VERSION := $(shell awk '/sigs\.k8s\.io\/controller-runtime/ {print substr($$2, 2)}' go.mod)
 CONTROLLER_GEN_VERSION := 0.4.1
 KUSTOMIZE_VERSION := 3.8.7
+STERN_VERSION = 1.13.1
 K8S_VERSION := 1.19.7
 KIND_VERSION := 0.10.0
 CERT_MANAGER_VERSION := 1.2.0
@@ -68,6 +69,9 @@ setup: ## Setup necessary tools.
 	$(CURL) https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv$(KUSTOMIZE_VERSION)/kustomize_v$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz | tar -xz -C $(BIN_DIR)
 	$(CURL) -o $(BIN_DIR)/kind https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-linux-amd64 && chmod a+x $(BIN_DIR)/kind
 	$(CURL) -o $(BIN_DIR)/kubectl https://storage.googleapis.com/kubernetes-release/release/v$(K8S_VERSION)/bin/linux/amd64/kubectl && chmod a+x $(BIN_DIR)/kubectl
+	$(CURL) -sLf https://github.com/stern/stern/releases/download/v$(STERN_VERSION)/stern_$(STERN_VERSION)_linux_amd64.tar.gz | tar -xz stern_$(STERN_VERSION)_linux_amd64/
+	mv stern_$(STERN_VERSION)_linux_amd64/stern $(BIN_DIR)/
+	rm -r stern_$(STERN_VERSION)_linux_amd64/
 
 .PHONY: clean
 clean: ## Clean files>

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ prepare: ## Prepare for kind test.
 	$(MAKE) cert-manager
 	$(MAKE) install
 	$(KUBECTL) label ns default actions.cybozu.com/pod-mutate=true
+	$(KUBECTL) label ns default actions.cybozu.com/runnerpool-validate=true
 	$(KUSTOMIZE) build --load_restrictor='none' $(KINDTEST_DIR)/manifests | $(KUBECTL) apply -f -
 
 .PHONY: github-secret

--- a/PROJECT
+++ b/PROJECT
@@ -12,4 +12,8 @@ resources:
   kind: RunnerPool
   path: github.com/cybozu-go/github-actions-controller/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    defaulting: true
+    validation: true
+    webhookVersion: v1
 version: "3"

--- a/cmd/controller/cmd/run.go
+++ b/cmd/controller/cmd/run.go
@@ -94,6 +94,11 @@ func run() error {
 		return err
 	}
 
+	if err = (&actionsv1alpha1.RunnerPool{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "RunnerPool")
+		return err
+	}
+
 	runnerSweeper := controllers.NewRunnerSweeper(
 		mgr.GetClient(),
 		ctrl.Log.WithName("runner-sweeper"),

--- a/controllers/podsweep_runner.go
+++ b/controllers/podsweep_runner.go
@@ -54,7 +54,6 @@ func (r *PodSweeper) Start(ctx context.Context) error {
 			err := r.run(ctx)
 			if err != nil {
 				r.log.Error(err, "failed to run a sweeping loop")
-				return err
 			}
 		}
 	}

--- a/controllers/runnersweep_runner.go
+++ b/controllers/runnersweep_runner.go
@@ -63,7 +63,6 @@ func (r *RunnerSweeper) Start(ctx context.Context) error {
 			err := r.run(ctx)
 			if err != nil {
 				r.log.Error(err, "failed to run a sweeping loop")
-				return err
 			}
 		}
 	}

--- a/kindtest/helper_test.go
+++ b/kindtest/helper_test.go
@@ -155,7 +155,7 @@ func equalNumExistingRunners(
 		}
 	}
 
-	if len(found) != numExisting {
+	if len(found) != numExisting || len(runnerMap) != numExisting {
 		return fmt.Errorf(
 			"%d runners should exist: pods %#v runners %#v",
 			numExisting,


### PR DESCRIPTION
This PR made the following change:
- make CI always fail when other available runners outside of CI exist
- output all pods' logs in CI
- modify PodSweeper and RunnerSweeper not to exit when error occurred as it unstabilizes controllers
- add the missing SetupWebhookWithManager in #7 

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>