### PR TITLE
slack-agent client: print error response

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -64,14 +65,15 @@ func (c *NotifierClient) PostResult(
 	if err != nil {
 		return err
 	}
-
 	defer res.Body.Close()
+
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf(
-			"status code should be %d, but got %d",
-			http.StatusOK,
-			res.StatusCode,
-		)
+		data, err := io.ReadAll(res.Body)
+		if err != nil {
+			return fmt.Errorf("status code: %d, failed to read response body: %s", res.StatusCode, err)
+		}
+		return fmt.Errorf("status code: %d, error: %s", res.StatusCode, string(data))
 	}
+
 	return nil
 }

--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"flag"
-	"fmt"
 	"os"
 	"time"
 
@@ -58,7 +57,6 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/deltime-annotate/cmd/root.go
+++ b/cmd/deltime-annotate/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -34,7 +33,6 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/slack-agent/cmd/root.go
+++ b/cmd/slack-agent/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -19,7 +18,6 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
- Output the error response when `slack-agent client` gets an error.
- Remove redundant error output.
     - `cobra.Command` will output an error by default.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>