### PR TITLE
Fix controllers test

### DIFF
--- a/controllers/runnerpool_controller.go
+++ b/controllers/runnerpool_controller.go
@@ -121,8 +121,10 @@ func (r *RunnerPoolReconciler) finalize(ctx context.Context, log logr.Logger, rp
 	d.SetNamespace(rp.GetNamespace())
 	d.SetName(rp.GetRunnerDeploymentName())
 	if err := r.Delete(ctx, d); err != nil {
-		log.Error(err, "failed to delete deployment")
-		return err
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to delete deployment")
+			return err
+		}
 	}
 	return nil
 }
@@ -249,7 +251,7 @@ func (r *RunnerPoolReconciler) reconcileDeployment(ctx context.Context, log logr
 		return err
 	}
 	if op != controllerutil.OperationResultNone {
-		log.Info("reconciled stateful set", "operation", string(op))
+		log.Info("reconciled deployment", "operation", string(op))
 	}
 
 	return nil

--- a/controllers/runnerpool_controller_test.go
+++ b/controllers/runnerpool_controller_test.go
@@ -11,17 +11,23 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var _ = Describe("RunnerPool reconciler", func() {
-	ctx := context.Background()
 	organizationName := "runnerpool-org"
 	repositoryNames := []string{"runnerpool-repo-1", "runnerpool-repo-2"}
 	namespace := "runnerpool-ns"
+	runnerPoolName := "runnerpool-1"
+	deploymentName := "runnerpool-1"
 	slackAgentServiceName := "slack-agent"
+
+	ctx := context.Background()
+	var mgrCtx context.Context
+	var mgrCancel context.CancelFunc
 
 	BeforeEach(func() {
 		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
@@ -38,11 +44,11 @@ var _ = Describe("RunnerPool reconciler", func() {
 			repositoryNames,
 			organizationName,
 		)
-		err = r.SetupWithManager(mgr)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(r.SetupWithManager(mgr)).To(Succeed())
 
+		mgrCtx, mgrCancel = context.WithCancel(context.Background())
 		go func() {
-			err := mgr.Start(ctx)
+			err := mgr.Start(mgrCtx)
 			if err != nil {
 				panic(err)
 			}
@@ -51,190 +57,44 @@ var _ = Describe("RunnerPool reconciler", func() {
 	})
 
 	AfterEach(func() {
-		ctx.Done()
+		mgrCancel()
 		time.Sleep(500 * time.Millisecond)
 	})
 
 	It("should create Namespace", func() {
-		By("creating namespace")
-		ctx := context.Background()
-		ns := &corev1.Namespace{}
-		ns.Name = namespace
-		err := k8sClient.Create(ctx, ns)
-		Expect(err).ToNot(HaveOccurred())
+		createNamespaces(ctx, namespace)
 	})
 
-	It("should not create Deployment", func() {
-		name := "runnerpool-0"
-		By("deploying RunnerPool resource without the container with the required name")
-		rp := &actionsv1alpha1.RunnerPool{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-			Spec: actionsv1alpha1.RunnerPoolSpec{
-				RepositoryName: repositoryNames[0],
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"app": name,
-					},
-				},
-				Template: actionsv1alpha1.PodTemplateSpec{
-					ObjectMeta: actionsv1alpha1.ObjectMeta{
-						Labels: map[string]string{
-							"app": name,
-						},
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "bad-name",
-								Image: "sample:latest",
-							},
-						},
-					},
-				},
-			},
-		}
-		err := k8sClient.Create(ctx, rp)
-		Expect(err).To(Succeed())
-
-		By("getting the created Deployment")
-		d := new(appsv1.Deployment)
-		nsn := types.NamespacedName{
-			Name:      name,
-			Namespace: namespace,
-		}
-		Eventually(func() error {
-			rp := new(actionsv1alpha1.RunnerPool)
-			if err := k8sClient.Get(ctx, nsn, rp); err != nil {
-				return err
-			}
-
-			return k8sClient.Get(ctx, nsn, d)
-		}, 5*time.Second).ShouldNot(Succeed())
-
-		By("deleting the created RunnerPool")
-		rp = &actionsv1alpha1.RunnerPool{}
-		err = k8sClient.Get(ctx, nsn, rp)
-		Expect(err).NotTo(HaveOccurred())
-		err = k8sClient.Delete(ctx, rp)
-		Expect(err).NotTo(HaveOccurred())
-
-		By("deploying RunnerPool resource with an invalid repository name")
-		rp = &actionsv1alpha1.RunnerPool{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-			Spec: actionsv1alpha1.RunnerPoolSpec{
-				RepositoryName: "bad-runnerpool-repo",
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"app": name,
-					},
-				},
-				Template: actionsv1alpha1.PodTemplateSpec{
-					ObjectMeta: actionsv1alpha1.ObjectMeta{
-						Labels: map[string]string{
-							"app": name,
-						},
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  constants.RunnerContainerName,
-								Image: "sample:latest",
-							},
-						},
-					},
-				},
-			},
-		}
-		err = k8sClient.Create(ctx, rp)
-		Expect(err).To(Succeed())
-
-		By("getting the created Deployment")
-		d = new(appsv1.Deployment)
-		nsn = types.NamespacedName{
-			Name:      name,
-			Namespace: namespace,
-		}
-		Eventually(func() error {
-			rp := new(actionsv1alpha1.RunnerPool)
-			if err := k8sClient.Get(ctx, nsn, rp); err != nil {
-				return err
-			}
-
-			return k8sClient.Get(ctx, nsn, d)
-		}, 5*time.Second).ShouldNot(Succeed())
-
-		By("deleting the created RunnerPool")
-		rp = &actionsv1alpha1.RunnerPool{}
-		err = k8sClient.Get(ctx, nsn, rp)
-		Expect(err).NotTo(HaveOccurred())
-		err = k8sClient.Delete(ctx, rp)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should create Deployment", func() {
-		name := "runnerpool-1"
+	It("should create Deployment with a service name of slack agent", func() {
 		By("deploying RunnerPool resource")
-		rp := &actionsv1alpha1.RunnerPool{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-			Spec: actionsv1alpha1.RunnerPoolSpec{
-				RepositoryName:        repositoryNames[0],
-				SlackAgentServiceName: &slackAgentServiceName,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"app": name,
-					},
-				},
-				Template: actionsv1alpha1.PodTemplateSpec{
-					ObjectMeta: actionsv1alpha1.ObjectMeta{
-						Labels: map[string]string{
-							"app": name,
-						},
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  constants.RunnerContainerName,
-								Image: "sample:latest",
-							},
-						},
-					},
-				},
+		rp := makeRunnerPoolTemplate(runnerPoolName, namespace)
+		rp.Spec.RepositoryName = repositoryNames[0]
+		rp.Spec.SlackAgentServiceName = &slackAgentServiceName
+		rp.Spec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name:  constants.RunnerContainerName,
+				Image: "sample:latest",
 			},
 		}
-		err := k8sClient.Create(ctx, rp)
-		Expect(err).To(Succeed())
+		Expect(k8sClient.Create(ctx, rp)).To(Succeed())
 
-		By("getting the created Deployment")
-		d := new(appsv1.Deployment)
-		nsn := types.NamespacedName{
-			Name:      name,
-			Namespace: namespace,
-		}
+		By("wating the RunnerPool become Bound")
 		Eventually(func() error {
 			rp := new(actionsv1alpha1.RunnerPool)
-			if err := k8sClient.Get(ctx, nsn, rp); err != nil {
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: runnerPoolName, Namespace: namespace}, rp); err != nil {
 				return err
 			}
-
-			if err := k8sClient.Get(ctx, nsn, d); err != nil {
-				return err
-			}
-
 			if !rp.Status.Bound {
 				return errors.New(`status "bound" should be true`)
 			}
 			return nil
-		}, 5*time.Second).Should(Succeed())
+		}).Should(Succeed())
 
+		By("getting the created Deployment")
+		d := new(appsv1.Deployment)
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: namespace}, d)).To(Succeed())
+
+		By("confirming the Deployment's manifests")
 		Expect(d.Labels[constants.RunnerOrgLabelKey]).To(Equal(organizationName))
 		Expect(d.Labels[constants.RunnerRepoLabelKey]).To(Equal(repositoryNames[0]))
 		Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
@@ -249,8 +109,150 @@ var _ = Describe("RunnerPool reconciler", func() {
 		Expect(c.Env[3].Name).To(Equal(constants.RunnerRepoEnvName))
 		Expect(c.Env[3].Value).To(Equal(repositoryNames[0]))
 		Expect(c.Env[4].Name).To(Equal(constants.RunnerPoolNameEnvName))
-		Expect(c.Env[4].Value).To(Equal(name))
+		Expect(c.Env[4].Value).To(Equal(runnerPoolName))
 		Expect(c.Env[5].Name).To(Equal(constants.SlackAgentEnvName))
 		Expect(c.Env[5].Value).To(Equal(slackAgentServiceName))
+
+		By("deleting the created RunnerPool")
+		deleteRunnerPool(ctx, runnerPoolName, namespace)
+
+		By("wating the Deployment is deleted")
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: namespace}, &appsv1.Deployment{})
+			return apierrors.IsNotFound(err)
+		}).Should(BeTrue())
+	})
+
+	It("should create Deployment without a service name of slack agent", func() {
+		By("deploying RunnerPool resource")
+		rp := makeRunnerPoolTemplate(runnerPoolName, namespace)
+		rp.Spec.RepositoryName = repositoryNames[1]
+		rp.Spec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name:  constants.RunnerContainerName,
+				Image: "sample:latest",
+			},
+		}
+		Expect(k8sClient.Create(ctx, rp)).To(Succeed())
+
+		By("wating the RunnerPool become Bound")
+		Eventually(func() error {
+			rp := new(actionsv1alpha1.RunnerPool)
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: runnerPoolName, Namespace: namespace}, rp); err != nil {
+				return err
+			}
+			if !rp.Status.Bound {
+				return errors.New(`status "bound" should be true`)
+			}
+			return nil
+		}).Should(Succeed())
+
+		By("getting the created Deployment")
+		d := new(appsv1.Deployment)
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: namespace}, d)).To(Succeed())
+
+		By("confirming the Deployment's manifests")
+		Expect(d.Labels[constants.RunnerOrgLabelKey]).To(Equal(organizationName))
+		Expect(d.Labels[constants.RunnerRepoLabelKey]).To(Equal(repositoryNames[1]))
+		Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
+		c := d.Spec.Template.Spec.Containers[0]
+		Expect(c.Env).To(HaveLen(5))
+		Expect(c.Env[0].Name).To(Equal(constants.PodNameEnvName))
+		Expect(c.Env[0].ValueFrom.FieldRef.FieldPath).To(Equal("metadata.name"))
+		Expect(c.Env[1].Name).To(Equal(constants.PodNamespaceEnvName))
+		Expect(c.Env[1].ValueFrom.FieldRef.FieldPath).To(Equal("metadata.namespace"))
+		Expect(c.Env[2].Name).To(Equal(constants.RunnerOrgEnvName))
+		Expect(c.Env[2].Value).To(Equal(organizationName))
+		Expect(c.Env[3].Name).To(Equal(constants.RunnerRepoEnvName))
+		Expect(c.Env[3].Value).To(Equal(repositoryNames[1]))
+		Expect(c.Env[4].Name).To(Equal(constants.RunnerPoolNameEnvName))
+		Expect(c.Env[4].Value).To(Equal(runnerPoolName))
+
+		By("deleting the created RunnerPool")
+		deleteRunnerPool(ctx, runnerPoolName, namespace)
+
+		By("wating the Deployment is deleted")
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: namespace}, &appsv1.Deployment{})
+			return apierrors.IsNotFound(err)
+		}).Should(BeTrue())
+	})
+
+	It("should not create Deployment without the container with the required name", func() {
+		By("deploying RunnerPool resource")
+		rp := makeRunnerPoolTemplate(runnerPoolName, namespace)
+		rp.Spec.RepositoryName = repositoryNames[0]
+		rp.Spec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name:  "bad-name",
+				Image: "sample:latest",
+			},
+		}
+		Expect(k8sClient.Create(ctx, rp)).To(Succeed())
+
+		By("confirming the Deployment is not created")
+		Consistently(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: namespace}, &appsv1.Deployment{})
+		}).ShouldNot(Succeed())
+
+		By("deleting the created RunnerPool")
+		deleteRunnerPool(ctx, runnerPoolName, namespace)
+	})
+
+	It("should not create Deployment with an invalid repository name", func() {
+		By("deploying RunnerPool resource")
+		rp := makeRunnerPoolTemplate(runnerPoolName, namespace)
+		rp.Spec.RepositoryName = "bad-runnerpool-repo"
+		rp.Spec.Template.Spec.Containers = []corev1.Container{
+			{
+				Name:  constants.RunnerContainerName,
+				Image: "sample:latest",
+			},
+		}
+		Expect(k8sClient.Create(ctx, rp)).To(Succeed())
+
+		By("confirming the Deployment is not created")
+		Consistently(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: namespace}, &appsv1.Deployment{})
+		}).ShouldNot(Succeed())
+
+		By("deleting the created RunnerPool")
+		deleteRunnerPool(ctx, runnerPoolName, namespace)
 	})
 })
+
+func makeRunnerPoolTemplate(name, namespace string) *actionsv1alpha1.RunnerPool {
+	return &actionsv1alpha1.RunnerPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			// Add a finalizer manually, because a webhook is not working in this test.
+			Finalizers: []string{constants.RunnerPoolFinalizer},
+		},
+		Spec: actionsv1alpha1.RunnerPoolSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name,
+				},
+			},
+			Template: actionsv1alpha1.PodTemplateSpec{
+				ObjectMeta: actionsv1alpha1.ObjectMeta{
+					Labels: map[string]string{
+						"app": name,
+					},
+				},
+			},
+		},
+	}
+}
+
+func deleteRunnerPool(ctx context.Context, name, namespace string) {
+	rp := &actionsv1alpha1.RunnerPool{}
+	rp.Name = name
+	rp.Namespace = namespace
+	ExpectWithOffset(1, k8sClient.Delete(ctx, rp)).To(Succeed())
+	EventuallyWithOffset(1, func() bool {
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &actionsv1alpha1.RunnerPool{})
+		return apierrors.IsNotFound(err)
+	}).Should(BeTrue())
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,12 +1,15 @@
 package controllers
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	actionsv1alpha1 "github.com/cybozu-go/github-actions-controller/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -28,6 +31,11 @@ var scheme = runtime.NewScheme()
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
+
+	SetDefaultEventuallyTimeout(10 * time.Second)
+	SetDefaultEventuallyPollingInterval(time.Second)
+	SetDefaultConsistentlyDuration(10 * time.Second)
+	SetDefaultConsistentlyPollingInterval(time.Second)
 
 	RunSpecsWithDefaultAndCustomReporters(t,
 		"Controller Suite",
@@ -65,3 +73,12 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+func createNamespaces(ctx context.Context, namespaces ...string) {
+	for _, n := range namespaces {
+		ns := &corev1.Namespace{}
+		ns.Name = n
+		err := k8sClient.Create(ctx, ns)
+		ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+	}
+}


### PR DESCRIPTION
- Bugfix: finalize fail when a runner deployment is not created.
- Fix controllers tests
   - Restart a manager in BeforeEach/AfterEach.
   - Add a finalizer for RunnerPool resources. (runnerpool controller test)
   - Add a test case without slack-agent service name. (runnerpool controller test)


Signed-off-by: Masayuki Ishii <masa213f@gmail.com>