### PR TITLE
Add trimpath option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,11 @@ generate:
 
 .PHONY: build
 build: generate ## Build all binaries.
-	go build -o $(BIN_DIR)/github-actions-controller ./cmd/controller
-	go build -o $(BIN_DIR)/ ./cmd/slack-agent
-	go build -o $(BIN_DIR)/ ./cmd/slack-agent-client
-	go build -o $(BIN_DIR)/ ./cmd/job-started
-	go build -o $(BIN_DIR)/ ./cmd/entrypoint
+	go build -o $(BIN_DIR)/github-actions-controller -trimpath ./cmd/controller
+	go build -o $(BIN_DIR)/ -trimpath ./cmd/entrypoint
+	go build -o $(BIN_DIR)/ -trimpath ./cmd/job-started
+	go build -o $(BIN_DIR)/ -trimpath ./cmd/slack-agent
+	go build -o $(BIN_DIR)/ -trimpath ./cmd/slack-agent-client
 
 .PHONY: image
 image: ## Build container images.

--- a/kindtest/runner_test.go
+++ b/kindtest/runner_test.go
@@ -114,7 +114,7 @@ func testRunner() {
 				}
 			}
 			return errors.New("one pod should have annotation " + constants.PodDeletionTimeKey)
-		}, time.Minute, time.Second).ShouldNot(HaveOccurred())
+		}, 3*time.Minute, time.Second).ShouldNot(HaveOccurred())
 		now := time.Now().UTC()
 		fmt.Println("====== Current time is " + now.Format(time.RFC3339))
 
@@ -159,7 +159,7 @@ func testRunner() {
 				}
 			}
 			return errors.New("one pod should have annotation " + constants.PodDeletionTimeKey)
-		}, time.Minute, time.Second).ShouldNot(HaveOccurred())
+		}, 3*time.Minute, time.Second).ShouldNot(HaveOccurred())
 		now := time.Now().UTC()
 		fmt.Println("====== Current time is " + now.Format(time.RFC3339))
 

--- a/kindtest/suite_test.go
+++ b/kindtest/suite_test.go
@@ -59,6 +59,8 @@ func TestOnKind(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	fmt.Println("testID: " + testID)
+
 	By("checking env variables")
 	Expect(binDir).ShouldNot(BeEmpty())
 	fmt.Println("This test uses the binaries under " + binDir)


### PR DESCRIPTION
- Add `trimpath` option.
    ```
    $ go help build
    ...
        -trimpath
                remove all file system paths from the resulting executable.
                Instead of absolute file system paths, the recorded file names
                will begin with either "go" (for the standard library),
                or a module path@version (when using modules),
                or a plain import path (when using GOPATH).
    ```
- Increase timeout when checking the deletion time annotation in the kindtest.
    - Sometimes it takes a long time to start a test job.
- Show a test id, at the start of the kindtest.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>