### PR TITLE
Add test for controller metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,8 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.26.0
 	github.com/slack-go/slack v0.9.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.0

--- a/metrics/client.go
+++ b/metrics/client.go
@@ -1,0 +1,65 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+var (
+	ErrNotExist  = errors.New("metrics is not exist")
+	ErrWrongType = errors.New("metrics type is wrong")
+)
+
+type Gauge struct {
+	Label map[string]string
+	Value float64
+}
+
+// FetchGauge fetches a gauge metrics. This is a helper function for tests.
+func FetchGauge(ctx context.Context, url, name string) ([]*Gauge, error) {
+	families, err := fetchMetricsFamily(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	family := families[name]
+	if family == nil {
+		return nil, ErrNotExist
+	}
+	if family.GetType() != dto.MetricType_GAUGE {
+		return nil, ErrWrongType
+	}
+
+	var ret []*Gauge
+	for _, m := range family.GetMetric() {
+		label := map[string]string{}
+		for _, l := range m.GetLabel() {
+			label[l.GetName()] = l.GetValue()
+		}
+		ret = append(ret, &Gauge{
+			Label: label,
+			Value: m.GetGauge().GetValue(),
+		})
+	}
+	return ret, nil
+}
+
+func fetchMetricsFamily(ctx context.Context, url string) (map[string]*dto.MetricFamily, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return (&expfmt.TextParser{}).TextToMetricFamilies(resp.Body)
+}


### PR DESCRIPTION
Add unit tests for controller metrics.

I defined the `metrics.FetchGauge` function, which is a helper function for testing metrics, in the `metrics` package instead of the `controllers` package, because I want to use it in some packages.
In the next PR, I will use it in the `runner` package.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>